### PR TITLE
Fix unused variable warnings

### DIFF
--- a/lib/phoenix_api_docs/blueprint_writer.ex
+++ b/lib/phoenix_api_docs/blueprint_writer.ex
@@ -106,32 +106,35 @@ defmodule PhoenixApiDocs.BlueprintWriter do
 
   defp process_requests(%{requests: requests}) when is_list(requests) do
     Enum.reduce requests, "", fn(request, docs) ->
-      docs
-      <>
-      case Map.fetch(request, :body) do
-        {:ok, body} ->
-          """
-
-          + Request json (application/json)
-            #{body}
-          """
-        :error ->
-          ""
-      end
-      <>
-      case Map.fetch(request, :response) do
-        {:ok, response} ->
-          """
-
-          + Response #{response.status}
-            #{response.body}
-          """
-        :error ->
-          ""
-      end
+      docs <> request_body(request) <> response_body(request)
     end
   end
 
   defp process_requests(_), do: ""
 
+  defp request_body(request) do
+    case Map.fetch(request, :body) do
+      {:ok, body} ->
+        """
+
+        + Request json (application/json)
+          #{body}
+        """
+      :error ->
+        ""
+    end
+  end
+
+  defp response_body(request) do
+    case Map.fetch(request, :response) do
+      {:ok, response} ->
+        """
+
+        + Response #{response.status}
+          #{response.body}
+        """
+      :error ->
+        ""
+    end
+  end
 end

--- a/lib/phoenix_api_docs/controller.ex
+++ b/lib/phoenix_api_docs/controller.ex
@@ -49,7 +49,7 @@ defmodule PhoenixApiDocs.Controller do
       case parameter do
         {:parameter, [name, type, :required, description]} ->
           list ++ [%{name: atom_to_string(name), type: atom_to_string(type), required: true, description: description}]
-        {:parameter, [path, name, type, :required]} ->
+        {:parameter, [_path, name, type, :required]} ->
           list ++ [%{name: atom_to_string(name), type: atom_to_string(type), required: true, description: ""}]
         {:parameter, [name, type, description]} ->
           list ++ [%{name: atom_to_string(name), type: atom_to_string(type), required: false, description: description}]


### PR DESCRIPTION
While using this package, I noticed that there were four warnings when I went to compile:

```
==> phoenix_api_docs
Compiling 7 files (.ex)
warning: variable path is unused
  lib/phoenix_api_docs/controller.ex:52

warning: variable docs is unused
  lib/phoenix_api_docs/blueprint_writer.ex:108

warning: function Phoenix.Naming.humanize/1 is undefined (module Phoenix.Naming is not available)
  lib/phoenix_api_docs/generator.ex:101

warning: function Phoenix.Naming.resource_name/2 is undefined (module Phoenix.Naming is not available)
  lib/phoenix_api_docs/generator.ex:101

Generated phoenix_api_docs app
```

I've taken the time to fix them all up. The `path` one was easy as it just needed to be prefixed with an underscore. The `docs` one was interesting as it was getting used. I decided to refactor some of the code and it looks like the compiler now recognizes that the `docs` variable is being used.

As for the functions from `Phoenix.Naming`, I tried `import`ing them, but it didn't go so well. It looks like the compiled code has no notion of a `Phoenix.Naming`, even if you `require` it.
